### PR TITLE
fix: set inter font family to UploadDropzone

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,6 +32,9 @@ export const uploaderOptions = {
     colors: {
       primary: '#000',
     },
+    fontFamilies: {
+      base: 'Inter',
+    }
   },
   tags: ['career_explorer'],
   locale: {


### PR DESCRIPTION
I observed we are using fontFamily: `inter` across this site, however, in UploadDropzone we are missing that.
So fixed the font family for UploadDropzone

BEFORE
<img width="482" alt="image" src="https://github.com/Nutlope/explorecareers/assets/38828053/b1658eec-ca86-4611-92a9-683a8b716bd1">

AFTER
<img width="534" alt="image" src="https://github.com/Nutlope/explorecareers/assets/38828053/9ac1a13c-137e-4123-9f69-6ab562b6188b">
